### PR TITLE
refactor: Release process

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -1,9 +1,10 @@
 name: semantic release
 
 on:
-  workflow_run:
-    workflows: [ Pull Request Closed ]
-    types: [ completed ]
+  push:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}
@@ -21,10 +22,18 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
+      - name: package helm chart
+        shell: bash
+        run: |
+          APP_VERSION=$(yq '.metabase.metabaseImage.tag' charts/nr-metabase/values.yaml)
+          # remove v from version as it only needs the numbers without v
+          VERSION=$(echo $APP_VERSION | sed 's/v//')
+          helm package -u --destination=.cr-release-packages --app-version="$APP_VERSION" --version=$VERSION charts/${{ github.event.repository.name }}
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          skip_packaging: 'true'
 
 

--- a/.github/workflows/on-pr-main.yml
+++ b/.github/workflows/on-pr-main.yml
@@ -25,7 +25,7 @@ jobs:
         id: read_yaml
         shell: bash
         run: |
-          appVersion=$(yq '.appVersion' charts/nr-metabase/Chart.yaml)
+          appVersion=$(yq '.metabase.metabaseImage.tag' charts/nr-metabase/values.yaml)
           echo "app version is $appVersion"
           echo "app_version=$appVersion" >> "$GITHUB_OUTPUT"
           if [ "$appVersion" != '' ]; then

--- a/charts/nr-metabase/templates/metabase/deployment.yaml
+++ b/charts/nr-metabase/templates/metabase/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ include "metabase.fullname" . }}
           securityContext:
             {{- toYaml .Values.metabase.securityContext | nindent 12 }}
-          image: "image-registry.openshift-image-registry.svc:5000/{{.Release.Namespace}}/{{ include "metabase.fullname" . }}:{{ .Chart.AppVersion }}"
+          image: "image-registry.openshift-image-registry.svc:5000/{{.Release.Namespace}}/{{ include "metabase.fullname" . }}:{{ .Values.metabase.metabaseImage.tag }}"
           imagePullPolicy: {{ .Values.metabase.image.pullPolicy }}
           env:
             - name: MB_DB_DBNAME

--- a/charts/nr-metabase/templates/metabase/is.yaml
+++ b/charts/nr-metabase/templates/metabase/is.yaml
@@ -9,9 +9,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - name: "{{ .Chart.AppVersion }}"
+    - name: "{{ .Values.metabase.metabaseImage.tag }}"
       from:
         kind: DockerImage
-        name: "{{ .Values.metabase.image.repository }}:{{ .Chart.AppVersion }}"
+        name: "{{ .Values.metabase.image.repository }}:{{ .Values.metabase.metabaseImage.tag }}"
       referencePolicy:
         type: Local

--- a/charts/nr-metabase/values.yaml
+++ b/charts/nr-metabase/values.yaml
@@ -11,7 +11,7 @@ global:
       helm.sh/policy: "keep"
   zone: 'prod' # it is required, could be pr-123, dev, test, prod
   domain: "apps.silver.devops.gov.bc.ca" # it is required, apps.silver.devops.gov.bc.ca for silver cluster
-  
+
 metabase:
   enabled: true
   replicaCount: 1
@@ -21,8 +21,6 @@ metabase:
   image:
     repository: ghcr.io/bcgov/nr-metabase/metabase
     pullPolicy: Always
-    # this is for renovate give updated image alert.
-    tag: 0.48.6
   # the below is for renovate to keep pushing PRs, so that it keeps getting updated.
   metabaseImage:
     repository: metabase/metabase


### PR DESCRIPTION
Currently , lot of manual work is needed to keep metabase version updated, after renovate sends the PR.

This PR address that shortcoming and adds necessary automation in place to support Renovate updates all the way through which avoids the need to manually update.