### PR TITLE
chore(ci): block patch updates for Docker/Helm images

### DIFF
--- a/charts/nr-metabase/values.yaml
+++ b/charts/nr-metabase/values.yaml
@@ -5,11 +5,11 @@ fullnameOverride: ""
 global:
   secrets:
     databasePassword: ~
-    databaseName: 'metabase'
-    databaseUser: 'metabase'
+    databaseName: "metabase"
+    databaseUser: "metabase"
     annotation:
       helm.sh/policy: "keep"
-  zone: 'prod' # it is required, could be pr-123, dev, test, prod
+  zone: "prod" # it is required, could be pr-123, dev, test, prod
   domain: "apps.silver.devops.gov.bc.ca" # it is required, apps.silver.devops.gov.bc.ca for silver cluster
 
 metabase:
@@ -25,7 +25,7 @@ metabase:
   # the below is for renovate to keep pushing PRs, so that it keeps getting updated.
   metabaseImage:
     repository: metabase/metabase
-    tag: v0.55.4
+    tag: v0.55.x
   containerPort: 3000
   environment: production
   service:
@@ -54,7 +54,7 @@ database:
     repository: artifacts.developer.gov.bc.ca/github-docker-remote/bcgov/nr-containers/postgres
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: '15.10'
+    tag: "15.10"
   podAnnotations: {}
   podSecurityContext: {}
   securityContext: {}

--- a/renovate.json
+++ b/renovate.json
@@ -6,18 +6,6 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "metabase/metabase",
-        "metabase"
-      ],
-      "matchDatasources": [
-        "docker",
-        "helm"
-      ],
-      "rangeStrategy": "minor",
-      "groupName": "metabase"
-    },
-    {
       "matchFileNames": [
         "charts/nr-metabase/values.yaml"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,6 @@
         "docker"
       ],
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,35 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "dockerfile"
+      "matchPackageNames": [
+        "metabase/metabase",
+        "metabase"
       ],
-      "pinDigests": false
-    },
-    {
-      "matchPackageNames": ["metabase/metabase", "metabase"],
-      "matchDatasources": ["docker", "helm"],
+      "matchDatasources": [
+        "docker",
+        "helm"
+      ],
       "rangeStrategy": "minor",
       "groupName": "metabase"
+    },
+    {
+      "matchFileNames": [
+        "charts/nr-metabase/values.yaml"
+      ],
+      "matchPackageNames": [
+        "metabase/metabase"
+      ],
+      "matchManagers": [
+        "helm-values"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,13 +6,10 @@
   ],
   "packageRules": [
     {
-      "matchFileNames": [
-        "charts/nr-metabase/values.yaml"
-      ],
-      "matchPackageNames": [
-        "metabase/metabase"
-      ],
       "matchManagers": [
+        "dockerfile",
+        "docker-compose",
+        "kubernetes",
         "helm-values"
       ],
       "matchDatasources": [


### PR DESCRIPTION
## Summary
Stop patch-only PRs for image tags across the repo while allowing minor/major updates. Prevents noise like [PR #147](https://github.com/bcgov/nr-metabase/pull/147/files).

## Rationale
Repo owners prefer to avoid frequent patch bumps for Docker/Helm images and Helm values; keep minors.

## Changes
- Add repo-wide rule to disable patch updates for Docker datasource in managers:
  - dockerfile, docker-compose, kubernetes, helm-values

## Impact
- No patch PRs for Docker image tags (including `metabase/metabase` in `values.yaml`).
- Minor/major updates continue as usual.